### PR TITLE
cut out visualization dependencies

### DIFF
--- a/domaps/domaps.py
+++ b/domaps/domaps.py
@@ -5,7 +5,6 @@ import plotly.express as px
 import plotly.graph_objects as go
 import plotly.figure_factory as ff
 from plotly.subplots import make_subplots
-import datashader as ds
 import re
 from io import BytesIO, StringIO
 from sklearn.decomposition import PCA
@@ -18,11 +17,6 @@ from scipy.stats import chi2
 from statsmodels.stats.multitest import multipletests
 from scipy.stats import combine_pvalues
 import statistics
-import matplotlib.pyplot as plt
-from matplotlib_venn import venn2, venn3
-from PIL import Image
-from upsetplot import from_memberships
-from upsetplot import plot as upplot
 import pkg_resources
 from scipy.stats import zscore
 import urllib.parse
@@ -31,6 +25,18 @@ import bisect
 import inspect
 import warnings
 from itertools import cycle, combinations
+
+try:
+    from upsetplot import from_memberships
+    from upsetplot import plot as upplot
+    import matplotlib.pyplot as plt
+    from matplotlib_venn import venn2, venn3
+    import datashader as ds
+    from PIL import Image
+except:
+    warnings.warn(
+        'Not all visualizations will work because of the following libraries is missing (upsetplot, matplotlib, matplotlib_venn or datashader). Run `pip install "domaps[viz]"`'
+    )
 
 from domaps.constants import (
     DataFrameStrings,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,8 @@ optional-dependencies.gui = { file = [ "requirements/requirements_gui.txt", "req
 ] }
 optional-dependencies.development = { file = ["requirements/requirements_development.txt"
 ] }
+optional-dependencies.viz = { file = ["requirements/requirements_viz.txt"
+] }
 
 version = {attr = "domaps.__version__"}
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,16 +1,10 @@
-matplotlib
-matplotlib-venn
-numba
 numpy<2
 plotly
 scikit-learn
 scipy
 statsmodels
-UpSetPlot
 requests
 statistics
 natsort
-datashader
 # TODO: Check difference between pandas 2.2.3 and pandas 2.0.0 (test_DOM_DDA fails)
 pandas==2.0.0
-dask<=2024.8 # pyarrow optional requirement is not actually optional

--- a/requirements/requirements_viz.txt
+++ b/requirements/requirements_viz.txt
@@ -1,0 +1,6 @@
+
+datashader
+dask<=2024.8 # pyarrow optional requirement is not actually optional
+UpSetPlot
+matplotlib
+matplotlib-venn

--- a/tests/test_usecases.py
+++ b/tests/test_usecases.py
@@ -5,6 +5,8 @@ import os
 import pkg_resources
 import json
 
+test_viz = False
+
 
 class TestAnalysis:
     filenames = {
@@ -93,7 +95,8 @@ class TestBenchmark:
         # run plotting functions
         comp.quantity_pr_pg_barplot_comparison(multi_choice)
         comp.coverage_comparison(multi_choice)
-        comp.venn_sections(multi_choice, omit_size=50)
+        if test_viz:
+            comp.venn_sections(multi_choice, omit_size=50)
         comp.get_complex_coverage(5)
         comp.plot_intramap_scatter(
             multi_choice=multi_choice,


### PR DESCRIPTION
Non-standard visualization libraries are now not in the standard requirements.
There is a loose requirements_viz that can be installed optionally, but all of those are also included in the stable requirements. This is only needed if the visualizations are to be created in python and not through the gui and one also wants to avoid the heavy GUI requirements.