### PR TITLE
Increase tested python versions

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -18,4 +18,4 @@ jobs:
       commitish_to_release: ${{ inputs.commitish_to_release }}
       package_name: "domaps"
       # optional parameters
-      python_version: "3.10"
+      python_version: "3.11"

--- a/.github/workflows/publish_on_pypi.yml
+++ b/.github/workflows/publish_on_pypi.yml
@@ -25,6 +25,6 @@ jobs:
       package_name: "domaps"
       tag_to_release: ${{ inputs.tag_to_release }}
       # optional parameters:
-      python_version: "3.10"
+      python_version: "3.11"
       test_stable: false
       only_testpypi_release: ${{ inputs.only_testpypi_release }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3

--- a/domaps/domaps.py
+++ b/domaps/domaps.py
@@ -1,5 +1,6 @@
 import natsort
 import numpy as np
+import os
 import pandas as pd
 import plotly.express as px
 import plotly.graph_objects as go
@@ -17,7 +18,6 @@ from scipy.stats import chi2
 from statsmodels.stats.multitest import multipletests
 from scipy.stats import combine_pvalues
 import statistics
-import pkg_resources
 from scipy.stats import zscore
 import urllib.parse
 import urllib.request
@@ -47,6 +47,8 @@ from domaps.constants import (
 )
 
 from domaps.__init__ import __version__ as version
+
+DOMAPS_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
 def natsort_index_keys(x):
@@ -144,14 +146,10 @@ class SpatialDataSet:
 
         # TODO: Extract this to a method
         self.organism = organism
-        if complexes + ".csv" in pkg_resources.resource_listdir(
-            __name__, "annotations/complexes"
-        ):
+        if complexes + ".csv" in os.listdir(DOMAPS_DIR + "/annotations/complexes"):
             # TODO: Deduplicate this code
             marker_table = pd.read_csv(
-                pkg_resources.resource_stream(
-                    __name__, "annotations/complexes/{}.csv".format(complexes)
-                )
+                f"{DOMAPS_DIR}/annotations/complexes/{complexes}.csv"
             )
         else:
             marker_table = pd.read_csv(StringIO(complexes))
@@ -162,15 +160,12 @@ class SpatialDataSet:
                 marker_table[DataFrameStrings.CLUSTER_MEMBERS],
             )
         }
-        if organelles + ".csv" in pkg_resources.resource_listdir(
-            __name__, "annotations/organellemarkers"
+        if organelles + ".csv" in os.listdir(
+            DOMAPS_DIR + "/annotations/organellemarkers"
         ):
             # TODO: Deduplicate this code
             df_organellarMarkerSet = pd.read_csv(
-                pkg_resources.resource_stream(
-                    __name__,
-                    "annotations/organellemarkers/{}.csv".format(organelles),
-                ),
+                f"{DOMAPS_DIR}/annotations/organellemarkers/{organelles}.csv",
                 usecols=lambda x: bool(
                     re.match(
                         f"{DataFrameStrings.COMPARTMENT}|{DataFrameStrings.COMPARTMENT_PROTEIN_ID}",
@@ -2426,9 +2421,7 @@ class SpatialDataSetComparison:
                 organism = "Homo sapiens - Uniprot"
 
             marker_table = pd.read_csv(
-                pkg_resources.resource_stream(
-                    __name__, "annotations/complexes/{}.csv".format(organism)
-                )
+                f"{DOMAPS_DIR}/annotations/complexes/{organism}.csv"
             )
             self.markerproteins = {
                 k: v.replace(" ", "").split(",")
@@ -5001,12 +4994,8 @@ def parse_reannotation_source(mode, source):
         if "\n" in source:
             idmapping = [el for el in source.split("\n")]
         else:
-            idmapping = [
-                el.decode("UTF-8").strip()
-                for el in pkg_resources.resource_stream(
-                    "domaps", f"annotations/idmapping/{source}.txt"
-                ).readlines()
-            ]
+            with open(f"{DOMAPS_DIR}/annotations/idmapping/{source}.txt") as f:
+                idmapping = [el.strip() for el in f.readlines()]
         reannotation_source["idmapping"] = idmapping
     elif mode == "tsv":
         if "\n" in source:
@@ -5015,9 +5004,7 @@ def parse_reannotation_source(mode, source):
             )
         else:
             idmapping = pd.read_csv(
-                pkg_resources.resource_stream(
-                    "domaps", f"annotations/idmapping/{source}.tab"
-                ),
+                f"{DOMAPS_DIR}/annotations/idmapping/{source}.tab",
                 sep="\t",
                 usecols=["Entry", "Gene names  (primary )"],
             )

--- a/domaps/domaps.py
+++ b/domaps/domaps.py
@@ -48,7 +48,7 @@ from domaps.constants import (
 
 from domaps.__init__ import __version__ as version
 
-DOMAPS_DIR = os.path.dirname(os.path.abspath(__file__))
+PACKAGE_ROOT_PATH = os.path.dirname(os.path.abspath(__file__))
 
 
 def natsort_index_keys(x):
@@ -146,10 +146,12 @@ class SpatialDataSet:
 
         # TODO: Extract this to a method
         self.organism = organism
-        if complexes + ".csv" in os.listdir(DOMAPS_DIR + "/annotations/complexes"):
+        if complexes + ".csv" in os.listdir(
+            PACKAGE_ROOT_PATH + "/annotations/complexes"
+        ):
             # TODO: Deduplicate this code
             marker_table = pd.read_csv(
-                f"{DOMAPS_DIR}/annotations/complexes/{complexes}.csv"
+                f"{PACKAGE_ROOT_PATH}/annotations/complexes/{complexes}.csv"
             )
         else:
             marker_table = pd.read_csv(StringIO(complexes))
@@ -161,11 +163,11 @@ class SpatialDataSet:
             )
         }
         if organelles + ".csv" in os.listdir(
-            DOMAPS_DIR + "/annotations/organellemarkers"
+            PACKAGE_ROOT_PATH + "/annotations/organellemarkers"
         ):
             # TODO: Deduplicate this code
             df_organellarMarkerSet = pd.read_csv(
-                f"{DOMAPS_DIR}/annotations/organellemarkers/{organelles}.csv",
+                f"{PACKAGE_ROOT_PATH}/annotations/organellemarkers/{organelles}.csv",
                 usecols=lambda x: bool(
                     re.match(
                         f"{DataFrameStrings.COMPARTMENT}|{DataFrameStrings.COMPARTMENT_PROTEIN_ID}",
@@ -2421,7 +2423,7 @@ class SpatialDataSetComparison:
                 organism = "Homo sapiens - Uniprot"
 
             marker_table = pd.read_csv(
-                f"{DOMAPS_DIR}/annotations/complexes/{organism}.csv"
+                f"{PACKAGE_ROOT_PATH}/annotations/complexes/{organism}.csv"
             )
             self.markerproteins = {
                 k: v.replace(" ", "").split(",")
@@ -4994,7 +4996,7 @@ def parse_reannotation_source(mode, source):
         if "\n" in source:
             idmapping = [el for el in source.split("\n")]
         else:
-            with open(f"{DOMAPS_DIR}/annotations/idmapping/{source}.txt") as f:
+            with open(f"{PACKAGE_ROOT_PATH}/annotations/idmapping/{source}.txt") as f:
                 idmapping = [el.strip() for el in f.readlines()]
         reannotation_source["idmapping"] = idmapping
     elif mode == "tsv":
@@ -5004,7 +5006,7 @@ def parse_reannotation_source(mode, source):
             )
         else:
             idmapping = pd.read_csv(
-                f"{DOMAPS_DIR}/annotations/idmapping/{source}.tab",
+                f"{PACKAGE_ROOT_PATH}/annotations/idmapping/{source}.tab",
                 sep="\t",
                 usecols=["Entry", "Gene names  (primary )"],
             )

--- a/domaps/domaps.py
+++ b/domaps/domaps.py
@@ -147,7 +147,7 @@ class SpatialDataSet:
         # TODO: Extract this to a method
         self.organism = organism
         if complexes + ".csv" in os.listdir(
-            PACKAGE_ROOT_PATH + "/annotations/complexes"
+            f"{PACKAGE_ROOT_PATH}/annotations/complexes"
         ):
             # TODO: Deduplicate this code
             marker_table = pd.read_csv(
@@ -163,7 +163,7 @@ class SpatialDataSet:
             )
         }
         if organelles + ".csv" in os.listdir(
-            PACKAGE_ROOT_PATH + "/annotations/organellemarkers"
+            f"{PACKAGE_ROOT_PATH}/annotations/organellemarkers"
         ):
             # TODO: Deduplicate this code
             df_organellarMarkerSet = pd.read_csv(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "domaps"
-requires-python = ">=3.8, <=3.11"
+requires-python = ">=3.8, <3.12"
 # 3.12 is not supported yet, as the stable requirement numba 0.58 is not supported anymore, 0.59 does not support python 3.8 anymore so this needs either a switch in the requirements, or depracating 3.8.
 dynamic = ["version", "dependencies", "optional-dependencies"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "domaps"
-requires-python = ">=3.8"
+requires-python = ">=3.8, <=3.11"
+# 3.12 is not supported yet, as the stable requirement numba 0.58 is not supported anymore, 0.59 does not support python 3.8 anymore so this needs either a switch in the requirements, or depracating 3.8.
 dynamic = ["version", "dependencies", "optional-dependencies"]
 
 authors = [

--- a/requirements/requirements_stable.txt
+++ b/requirements/requirements_stable.txt
@@ -62,7 +62,7 @@ nodeenv==1.9.1
 notebook==6.0.0
 openpyxl==3.1.2
 overrides==7.7.0
-pandas==2.0.0
+pandas==2.2.3
 pandocfilters==1.5.1
 partd==1.4.1
 patsy==0.5.6

--- a/requirements/requirements_stable.txt
+++ b/requirements/requirements_stable.txt
@@ -1,5 +1,5 @@
 dask==2023.5.0
-matplotlib==3.5.3
+matplotlib==3.6.3
 matplotlib-venn==0.11.6
 numba==0.58.1
 numpy==1.24.4
@@ -62,7 +62,7 @@ nodeenv==1.9.1
 notebook==6.0.0
 openpyxl==3.1.2
 overrides==7.7.0
-pandas==2.2.3
+pandas==2.2.2
 pandocfilters==1.5.1
 partd==1.4.1
 patsy==0.5.6

--- a/tests/test_SpatialDataSetComparison.py
+++ b/tests/test_SpatialDataSetComparison.py
@@ -6,11 +6,11 @@ import pandas as pd
 from unittest.mock import patch
 
 filenames_HeLa = [
-    el
-    for el in os.listdir(
+    reference_dataset
+    for reference_dataset in os.listdir(
         os.path.join(os.path.dirname(__file__), "../domaps/referencedata")
     )
-    if "HeLa" in el
+    if "HeLa" in reference_dataset
 ]
 
 filenames_minimal = [

--- a/tests/test_SpatialDataSetComparison.py
+++ b/tests/test_SpatialDataSetComparison.py
@@ -1,14 +1,15 @@
 from domaps import SpatialDataSetComparison
 import json
 import os
-import pkg_resources
 from pytest import fixture
 import pandas as pd
 from unittest.mock import patch
 
 filenames_HeLa = [
-    os.path.join(os.path.dirname(__file__), "../domaps/referencedata/" + el)
-    for el in pkg_resources.resource_listdir("domaps", "referencedata")
+    el
+    for el in os.listdir(
+        os.path.join(os.path.dirname(__file__), "../domaps/referencedata")
+    )
     if "HeLa" in el
 ]
 

--- a/tests/test_usecases.py
+++ b/tests/test_usecases.py
@@ -2,7 +2,6 @@ from pandas import read_csv
 from pandas.testing import assert_frame_equal
 from domaps import SpatialDataSet, SpatialDataSetComparison
 import os
-import pkg_resources
 import json
 
 test_viz = False
@@ -112,8 +111,10 @@ class TestBenchmark:
 
     def test_referencedata_HeLa(self):
         filenames = [
-            os.path.join(os.path.dirname(__file__), "../domaps/referencedata/" + el)
-            for el in pkg_resources.resource_listdir("domaps", "referencedata")
+            os.path.join(os.path.dirname(__file__), "../domaps/referencedata", el)
+            for el in os.listdir(
+                os.path.join(os.path.dirname(__file__), "../domaps/referencedata")
+            )
             if "HeLa" in el
         ]
         self.run_benchmark(filenames, svm=False)


### PR DESCRIPTION
ProteoBench bumped to 3.11-3.13 so I need to include at least one of them.
pkg_resources was depracated.
3.12 does not work with stable numba 0.58 (need a switch or depracate 3.8)
3.13 does not work with pandas 2.2.2 https://github.com/JuliaS92/SpatialProteomicsQC/actions/runs/13721115446/job/38376609416